### PR TITLE
Check for translations that already exist in vendor package (duplicates)

### DIFF
--- a/check-translations.php
+++ b/check-translations.php
@@ -48,24 +48,36 @@ if (! $languages) {
 }
 
 $missing = [];
+$duplicates = [];
 foreach ($languages as $language) {
     $language = basename($language, '.json');
-    $translationKeys = array_unique($translationKeys);
+    $missing[$language] = 0;
+    $duplicates[$language] = 0;
+    $translations = [];
 
-    $translations = (array) json_decode(file_get_contents("lang/$language.json"));
+    // Find all vendor translation files and merge them into one array
     $vendorfiles = array_merge(
         glob("vendor/*/*/lang/$language.json"),
         glob("vendor/*/*/resources/lang/$language.json")
     );
-    foreach($vendorfiles as $file) {
+    foreach ($vendorfiles as $file) {
         $translations = array_merge(
             $translations,
-            (array) json_decode(file_get_contents($file))
+            (array) json_decode(file_get_contents($file)),
         );
     }
 
-    $missing[$language] = 0;
-    foreach ($translationKeys as $key) {
+    // Check for duplicate translations only after merging in all the vendor translations
+    $packageTranslations = (array) json_decode(file_get_contents("lang/$language.json"));
+    $duplicateKeys = array_intersect(array_keys($packageTranslations), array_keys($translations));
+    foreach ($duplicateKeys as $duplicate) {
+        $duplicates[$language]++;
+        error_log("a vendor package already accounted for translation key in language '$language': \"{$duplicate}\"");
+    }
+    $translations = array_merge($translations, $packageTranslations);
+
+    // Match existing translations with found translation strings
+    foreach (array_unique($translationKeys) as $key) {
         if (! array_key_exists($key, $translations)) {
             $missing[$language]++;
             error_log("missing translation in language '$language': \"{$key}\"");
@@ -86,7 +98,20 @@ foreach($missing as $language => $missingLang) {
     }
 }
 
-if($totalMissing > 0) {
+$totalDuplicates = 0;
+foreach($duplicates as $language => $duplicatesLang) {
+    if ($duplicatesLang > 0) {
+        if ($duplicatesLang == 1) {
+            error_log("1 translation is a duplicate of a vendor translation in language '$language'.");
+        } else {
+            error_log("$duplicatesLang translations are duplicates of vendor translations in language '$language'.");
+        }
+
+        $totalDuplicates += $duplicatesLang;
+    }
+}
+
+if ($totalMissing + $totalDuplicates > 0) {
     exit(1);
 }
 


### PR DESCRIPTION
For packages like `checkout-theme` we want to make sure we're not duplicating translation keys, as this can result in undefined behavior: whichever package gets booted last will win the "translation battle".